### PR TITLE
DNS update: public IP changed to 192.168.0.6

### DIFF
--- a/dns/variables.tf
+++ b/dns/variables.tf
@@ -7,7 +7,7 @@ variable "domain_cguertin" {
 variable "router_ip" {
   description = "Router IP address"
   type        = string
-  default     = "24.200.237.46"
+  default     = "192.168.0.6"
 }
 
 variable "domains" {


### PR DESCRIPTION
# DNS Changes Report

Public IP successfully updated to `192.168.0.6`.

**Zone Name**: cguertin.dev
**Record Name**: lb
**New IP Address**: 192.168.0.6
**Old IP Address**: 24.200.237.46

Changes were successfully made to your Cloudflare account.