### PR TITLE
Set Resources on jellyfin deployment, enable quicksync

### DIFF
--- a/services/mediaplatform/kustomization.yaml
+++ b/services/mediaplatform/kustomization.yaml
@@ -49,7 +49,7 @@ helmCharts:
     resources:
       # Warning: No limits.
       requests:
-        cpu: '4' # take the whole node, so that no other workload can be scheduled on it.
+        cpu: '7' # take the whole node, so that no other workload can be scheduled on it. (there are 8 cores, but let's use 7)
         memory: 8Gi
   version: 9.5.3
 # Below charts live here -> https://github.com/k8s-at-home/charts/tree/master/charts/stable

--- a/services/mediaplatform/kustomization.yaml
+++ b/services/mediaplatform/kustomization.yaml
@@ -46,6 +46,11 @@ helmCharts:
       config:
         enabled: true
         size: 2Gi
+    resources:
+      # Warning: No limits.
+      requests:
+        cpu: '4' # take the whole node, so that no other workload can be scheduled on it.
+        memory: 8Gi
   version: 9.5.3
 # Below charts live here -> https://github.com/k8s-at-home/charts/tree/master/charts/stable
 - name: radarr
@@ -147,6 +152,7 @@ images:
 patches:
 # - path: patches/set-plex-lb-ip-patch.yml # set hardcoded IP on Plex Load Balancer -> TODO: UNCOMMENT if plex redeployed.
 - path: patches/container-auth-patch.yml # add env variables to each service
+- path: patches/jellyfin-intel-quick-sync-patch.yml # configure Intel Quick Sync on Jellyfin
 - path: patches/pvc-mediaserver-player-patch.yml
   target:
     group: apps

--- a/services/mediaplatform/patches/jellyfin-affinity-rules-patch.yml
+++ b/services/mediaplatform/patches/jellyfin-affinity-rules-patch.yml
@@ -1,0 +1,18 @@
+## Docs: https://jellyfin.org/docs/general/administration/hardware-acceleration/intel/#kubernetes
+#
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: jellyfin
+spec:
+  template:
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+                - key: kubernetes.io/hostname
+                  operator: In
+                  values:
+                    - mediaserver

--- a/services/mediaplatform/patches/jellyfin-intel-quick-sync-patch.yml
+++ b/services/mediaplatform/patches/jellyfin-intel-quick-sync-patch.yml
@@ -11,7 +11,7 @@ spec:
         runAsUser: 1000
         runAsGroup: 1000
         supplementalGroups:
-        - 122 # Change this to match your "render" host group id and remove this comment
+        - 109 # ID of the 'render' group
       containers:
       - name: "jellyfin"
         securityContext:

--- a/services/mediaplatform/patches/jellyfin-intel-quick-sync-patch.yml
+++ b/services/mediaplatform/patches/jellyfin-intel-quick-sync-patch.yml
@@ -1,0 +1,25 @@
+## Docs: https://jellyfin.org/docs/general/administration/hardware-acceleration/intel/#kubernetes
+#
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: jellyfin
+spec:
+  template:
+    spec:
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+        supplementalGroups:
+        - 122 # Change this to match your "render" host group id and remove this comment
+      containers:
+      - name: "jellyfin"
+        securityContext:
+          privileged: true # Container must run as privileged inside of the pod
+        volumeMounts:
+        - name: "render-device"
+          mountPath: "/dev/dri/renderD128"
+      volumes:
+      - name: "render-device"
+        hostPath:
+          path: "/dev/dri/renderD128"


### PR DESCRIPTION
* Set `resources` on `jellyfin` deployment, occupy the whole node
* Set affinity rules on `jellyfin` deployment
* Use Quick Sync Video on `jellyfin` deployment